### PR TITLE
WIP Bind the decoder to req.body

### DIFF
--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -113,7 +113,7 @@ main() {
         }, optional: ['bar']));
     var rq = MockHttpRequest('GET', Uri(path: 'foo'));
     await AngelHttp(app).handleRequest(rq);
-    var body = await rq.response.transform(utf8.decoder).join();
+    var body = await utf8.decoder.bind(rq.response).join();
     expect(json.decode(body), 2);
   });
 

--- a/test/di_test.dart
+++ b/test/di_test.dart
@@ -28,7 +28,7 @@ main() {
     app.container.registerSingleton(Todo(text: TEXT, over: OVER));
     app.container.registerFactory<Future<Foo>>((container) async {
       var req = container.make<RequestContext>();
-      var text = await req.body.transform(utf8.decoder).join();
+      var text = await utf8.decoder.bind(req.body).join();
       return Foo(text);
     });
 


### PR DESCRIPTION
Hey I noticed that there were some failing tests due to some type issues. I've been trying to fix them all for the dart:stable build but I've had a ton of trouble getting "test/controller_test.dart: controller in group" to pass with the ANGEL_ENV=production flag. Do you have any ideas why that would fail? All the tests pass in dart:stable without this flag.